### PR TITLE
fix background black problem

### DIFF
--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -7,5 +7,7 @@
         <item name="colorPrimaryDark">@android:color/darker_gray</item>
         <item name="colorAccent">@android:color/darker_gray</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowAnimationStyle">@style/SlideRightAnimation</item>
     </style>
 </resources>


### PR DESCRIPTION
add
 //if you don't set this the background will be black when you slide.
    <item name="android:windowIsTranslucent">true</item>
    //set the right in/out animation of Activity,you can change this to yours
    <item name="android:windowAnimationStyle">@style/SlideRightAnimation</item>
to v21/style.xml